### PR TITLE
add node engine version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "test": "mocha --reporter spec server/test"
   },
+  "engines": {
+    "node": ">=4.1.1"
+  },
   "dependencies": {
     "async": "^1.5.2",
     "chai": "^3.4.1",


### PR DESCRIPTION
Add a node engine version dependency, to inform that the server won't work with older node version, i.e. under 4.1.1. Currently the engines dependency only gives warning when trying to run npm install from parent folder, see http://www.marcusoft.net/2015/03/packagejson-and-engines-and-enginestrict.html

Anyways, I think it's nice to have it explicitly in the package.json, as I used some time to debug the error when using node v0.12.7
