### PR TITLE
fix/ give options for boot function precedence over credentials file

### DIFF
--- a/server/test/test-iothub-api.js
+++ b/server/test/test-iothub-api.js
@@ -9,7 +9,7 @@ var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 var expect = chai.expect;
 
-var testUserCreds = {email: 'testuser@hub.fi', password: 'testPassword'};
+var testUserCreds = {username:'testuser', email: 'testuser@hub.fi', password: 'testPassword'};
 var testUserId;
 var testUserToken;
 


### PR DESCRIPTION
- fixes issue with tests, which happens because local credentials file
  overrides test credentials given to boot function. Because of this,
  when running tests the admin for server api was taken from the file,
  but tests used credentials specified for the tests, and tests failed
- now credentials given to boot function override options set in any
  credentials file, so tests are run correctly
- no credentials file needs to exist for tests to work. Just pull
  source, npm install and npm test
- add username to make it easy to confirm that test user was used for
  running tests
